### PR TITLE
Drop trailing colon from output of toString(TestInput)

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -23,7 +23,7 @@ code TestInput := T -> T#"code"
 locate TestInput := T -> new FilePosition from (T#"filename",
     T#"line number" - depth net code T, 1,
     T#"line number", 1,,)
-toString TestInput := T -> toString locate T | ":"
+toString TestInput := toString @@ locate
 net TestInput := T -> (toString T)^-1
 editMethod TestInput := EDIT @@ locate
 


### PR DESCRIPTION
No longer necessary with latest M2-mode update (https://github.com/Macaulay2/M2-emacs/pull/35).