### PR TITLE
Use "locate" for error msg when documentation is already provided

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -316,8 +316,9 @@ storeRawDocumentation := (tag, rawdoc) -> (
     fkey := format tag;
     if currentPackage#rawKey#?fkey and signalDocumentationError tag then (
 	rawdoc = currentPackage#rawKey#fkey;
-	printerr("error: documentation already provided for ", format tag);
-	printerr(rawdoc#"filename", ":", toString rawdoc#"linenum", ": ... here is the (end of the) previous documentation"));
+	error("documentation already provided for ", format tag, newline,
+	    toString locate rawdoc.DocumentTag,
+	    ": ... here is the (end of the) previous documentation"));
     currentPackage#rawKey#fkey = rawdoc)
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Here's some more `locate`-related code I noticed that would probably make sense to include in #2760.  In particular, the previous message didn't include a column number, and also an error wasn't actually raised.

### Before
```m2
i1 : loadPackage("Foo", FileName => "~/tmp/Foo.m2", LoadDocumentation => true)
 -- error: documentation already provided for foo
 -- /home/profzoom/tmp/Foo.m2:23: ... here is the (end of the) previous documentation
```

### After

```m2
i1 : loadPackage("Foo", FileName => "~/tmp/Foo.m2", LoadDocumentation => true)
/home/profzoom/tmp/Foo.m2:60:1:(2):[7]: error: documentation already provided for foo
/home/profzoom/tmp/Foo.m2:23:0: ... here is the (end of the) previous documentation
```