### PR TITLE
Provide both old and new file positions for duplicate documentation

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -315,10 +315,13 @@ formatDocumentTag Sequence := s -> concatenate (
 storeRawDocumentation := (tag, rawdoc) -> (
     fkey := format tag;
     if currentPackage#rawKey#?fkey and signalDocumentationError tag then (
+	newloc := toString new FilePosition from (
+	    minimizeFilename rawdoc#"filename", rawdoc#"linenum", 0);
 	rawdoc = currentPackage#rawKey#fkey;
-	error("documentation already provided for ", format tag, newline,
-	    toString locate rawdoc.DocumentTag,
-	    ": ... here is the (end of the) previous documentation"));
+	oldloc := toString locate rawdoc.DocumentTag;
+	printerr("error: documentation already provided for ", format tag);
+	printerr(newloc, ": ... here is the (end of the) new documentation");
+	printerr(oldloc, ": ... here is the (end of the) previous documentation"));
     currentPackage#rawKey#fkey = rawdoc)
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -743,7 +743,7 @@ installPackage Package := opts -> pkg -> (
 
 	-- should this be here, or farther up? Note: assembleTree resets the counters, so stay above that.
 	if chkdoc and hadDocumentationError then error(
-	    toString numDocumentationErrors, " errors(s) occurred in processing documentation for package ", toString pkg);
+	    toString numDocumentationErrors, " error(s) occurred in processing documentation for package ", toString pkg);
 
 	if pkg#?rawKeyDB and isOpen pkg#rawKeyDB then close pkg#rawKeyDB;
 
@@ -786,7 +786,7 @@ installPackage Package := opts -> pkg -> (
 			))));
 
 	if chkdoc and hadDocumentationError then error(
-	    toString numDocumentationErrors, " errors(s) occurred in documentation for package ", toString pkg);
+	    toString numDocumentationErrors, " error(s) occurred in documentation for package ", toString pkg);
 
 	-- make info documentation
 	-- ~60 -> ~70s for Macaulay2Doc


### PR DESCRIPTION
This is a followup to #6.  Ironically, I ran into exactly this duplicate documentation error in the Github actions for #2776.  it turns out that we actually shouldn't raise an error right away, as `installPackage` waits until the end and raises one error for everything.

So we restore the original `printerr` behavior, but also print both the original and the new file positions for easier debugging.

For example:

```m2
i1 : installPackage "Foo"
 -- error: documentation already provided for foo
 -- .Macaulay2/code/Foo.m2:17:0: ... here is the (end of the) new documentation
 -- .Macaulay2/code/Foo.m2:12:0: ... here is the (end of the) previous documentation
stdio:1:1:(3): error: 1 error(s) occurred in processing documentation for package Foo
```
