### PR TITLE
Update Python code for Expr error messages

### DIFF
--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -403,7 +403,7 @@ wrappedM2Function(self:pythonObject, args:pythonObject):pythonObjectOrNull := (
     when r
     is e:Error do (
 	Ccode(void, "PyErr_SetString(PyExc_RuntimeError, ",
-	    tocharstar(e.message), ")");
+	    tocharstar(tostringerror(e.message)), ")");
 	pythonObjectOrNull(null()))
     is o:pythonObjectCell do pythonObjectOrNull(o.v)
     else (


### PR DESCRIPTION
While working on https://github.com/Macaulay2/M2/pull/3173, I noticed that the `vanilla` branch didn't compile with Python support enabled due to the changes in e94290c1efe81fe2db2f91b3490e464caa08b1da, changing `Error` messages from `string`'s to `Expr`'s.  This fixes it.