### PR TITLE
Use the run whitelist for get w/ exclamation point, too

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -739,7 +739,7 @@ getfun(e:Expr):Expr := (
 	  is e:errmsg do buildErrorPacket(e.message)
 	  is s:stringCell do toExpr(s.v))
      else WrongArg("a string as filename"));
-setupfun("get",getfun);
+setupfun("get",getfun).Protected=false;
 
 readprompt := "";
 readpromptfun():string := readprompt;

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -91,9 +91,9 @@ undocumented' = x -> error "late use of function undocumented'"
 
 unexportedSymbols = () -> hashTable apply(pairs Core#"private dictionary", (n,s) -> if not Core.Dictionary#?n then (s => class value s => value s))
 
-
--- added: prevent run
+-- prevent running arbitrary code on Macaulay2Web
 run0 := run
+get0 := get
 allowedRuns := {
     "4ti2",
     "M2",
@@ -131,12 +131,14 @@ allowedRuns := {
     "which"
     }
 
-run = x -> (
-    if debugLevel>0 then "running " << x << endl;
-    for s in allowedRuns do if match("^"|s|"|/"|s,x) then return run0 x;
-    1)
---
-
+secureRun := (runf, strf, x) -> (
+    if debugLevel > 0 then printerr("running: ", x);
+    if any(allowedRuns, s -> match("^"|s|"|/"|s, strf x)) then runf x
+    else error "cannot run this command on Macaulay2Web")
+run = x -> secureRun(run0, identity, x)
+get = x -> (
+    if x#?0 and x#0 == "!" then secureRun(get0, substring_1, x)
+    else get0 x)
 
 Function.GlobalReleaseHook = (X,x) -> (
      if dictionary X =!= User#"private dictionary" then warningMessage(X," redefined");


### PR DESCRIPTION
I'd forgotten about this until the TOPCOM stuff reminded me...

A few months ago, Anton and I met with Georgia Tech IT and they were concerned about `get` running arbitrary code when the first character of the argument is `!`, e.g., `get "!echo Hello, world!"`.

This patch adds a wrapper around `get` that passes any `!`-leading string through the same whitelist as `run`.